### PR TITLE
Never use `using Foo`; instead, either use `import Foo`, or use `using Foo: f, g, h`

### DIFF
--- a/src/PreprocessMD.jl
+++ b/src/PreprocessMD.jl
@@ -1,19 +1,24 @@
-
 """
 Medically informed data transformations
 """
 module PreprocessMD
 
-using DataFrames
-
-import ScientificTypes: coerce!
-import ScientificTypesBase: OrderedFactor
+using DataFrames: AbstractDataFrame
+using DataFrames: Not
+using DataFrames: combine 
+using DataFrames: groupby
+using DataFrames: insertcols!
+using DataFrames: nrow
+using DataFrames: select
+using DataFrames: unstack
+using ScientificTypes: coerce!
+using ScientificTypesBase: OrderedFactor
 
 export add_label_column!, pivot, repr
 
 """
 	function add_label_column!(df::AbstractDataFrame, symb::Symbol, target_df::AbstractDataFrame)::Nothing
-Add column to a DataFrame based on symbol presence in the target DataFrame 
+Add column to a DataFrame based on symbol presence in the target DataFrame
 
 """
 function add_label_column!(


### PR DESCRIPTION
## Good

```julia
import Foo
```

```julia
using Foo: f

using Foo: g, h
```

## Bad

```julia
using Foo
```

This is bad because it brings all of `Foo`'s `export`ed names into scope, which:
1. Makes it hard to know which names come from where.
2. Can lead to your code breaking in the future when two of your dependencies start `export`ing the same name. This can cause your code to break even though none of your dependencies have made breaking releases.

```julia
import Foo: f

import Foo: g, h
```

This allows you to accidentally add methods to `f`, `g,` and `h` without needing to explicitly qualify them as `Foo.f`, `Foo.g`, etc.