### PR TITLE
The package's `Project.toml` file should only include the dependencies actually used in the source code of the package itself

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -5,14 +5,11 @@ version = "0.1.0"
 
 [deps]
 DataFrames = "a93c6f00-e57d-5684-b7b6-d8193f3e46c0"
-Documenter = "e30172f5-a6a5-5a46-863b-614d45cd2de4"
-REPLHistory = "a5566ce3-012c-4b09-85b8-62131f0c3f36"
 ScientificTypes = "321657f4-b219-11e9-178b-2701a2544e81"
 ScientificTypesBase = "30f210dd-8aff-4c5f-94ba-8e64358c1161"
 
 [compat]
 DataFrames = "1.3"
-Documenter = "0.27.16"
 ScientificTypes = "2.0.1"
 ScientificTypesBase = "2"
 julia = "1.6"


### PR DESCRIPTION
The package's `Project.toml` file should only include the dependencies actually used in the source code of the package itself.

For dependencies that are used during development, instead of adding them to the package's `Project.toml` file, you can add them to your default global environment.

Example usage:
```
git clone git@github.com:bcbi/PreprocessMD.jl.git
cd PreprocessMD.jl
julia -e 'import Pkg; Pkg.add("REPLHistory")' # this installs REPLHistory.jl in your global environment, NOT in the package's environment
julia --project -e 'import Pkg; Pkg.add("DataFrames")' # this installs DataFrames.jl in the package's environment
```

See also:
- https://docs.julialang.org/en/v1/manual/code-loading/
- https://pkgdocs.julialang.org/v1/environments/