### PR TITLE
Correct dependencies

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "PreprocessMD"
 uuid = "f785c8c6-3d80-4813-989a-2eb5f27d6bef"
 authors = ["Ashlin Harris <ashlin_harris@brown.edu>"]
-version = "3.0.0"
+version = "3.1.0"
 
 [deps]
 DataFrames = "a93c6f00-e57d-5684-b7b6-d8193f3e46c0"
@@ -10,4 +10,4 @@ MLJ = "add582a8-e3ab-11e8-2d5e-e98b27df1bc7"
 [compat]
 DataFrames = "1.3.2"
 MLJ = "0.17.1, 0.18"
-julia = "1.6"
+julia = "1.6, 1.7"

--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "PreprocessMD"
 uuid = "f785c8c6-3d80-4813-989a-2eb5f27d6bef"
 authors = ["Ashlin Harris <ashlin_harris@brown.edu>"]
-version = "3.1.0"
+version = "3.0.1"
 
 [deps]
 DataFrames = "a93c6f00-e57d-5684-b7b6-d8193f3e46c0"

--- a/test/Project.toml
+++ b/test/Project.toml
@@ -2,12 +2,10 @@
 CSV = "336ed68f-0bac-5ca0-87d4-7b16caf5d00b"
 DataFrames = "a93c6f00-e57d-5684-b7b6-d8193f3e46c0"
 MLJ = "add582a8-e3ab-11e8-2d5e-e98b27df1bc7"
-MLJDecisionTreeInterface = "c6f25543-311c-4c74-83dc-3ea6d1015661"
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 
 [compat]
 CSV = "0.10.2"
 DataFrames = "1.3.2"
-MLJ = "0.17.1"
-MLJDecisionTreeInterface = "0.2.2"
-julia = "1.6"
+MLJ = "0.17.1, 0.18"
+julia = "1.6, 1.7"

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -19,7 +19,6 @@ using MLJ: machine
 using MLJ: mode
 using MLJ: partition
 using MLJ: predict
-using MLJDecisionTreeInterface: DecisionTreeClassifier
 
 using Test: @testset
 using Test: @test


### PR DESCRIPTION
Formerly, `MLJDecisionTreeInterface` was included as a dependency, but it was actually not being used.

Also, the package has been tested for `julia 1.6` and `julia 1.7`, so these are both included in `Project.toml` and `test/Project.toml`.