### PR TITLE
`.gitattributes`: set `text=auto`

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+* text=auto


### PR DESCRIPTION
This should force Git to normalize the line endings to LF.